### PR TITLE
Empty Page Title Fix

### DIFF
--- a/enhanceApp.js
+++ b/enhanceApp.js
@@ -18,7 +18,10 @@ export default ({ Vue, options, router, siteData }) => {
                 const siteTitle = this.$siteTitle
                 const selfTitle = page.frontmatter.home ? null : (
                     page.frontmatter.title || // explicit title
-                    page.title.replace(/[_`]/g, '') // inferred title
+                    (
+                        // inferred title
+                        page.title ? page.title.replace(/[_`]/g, '') : 'Page Not Found'
+                    )
                 )
                 return siteTitle
                     ? selfTitle

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vuepress-theme-craftdocs",
-  "version": "1.1.10",
+  "version": "1.1.11",
   "description": "vuepress-theme",
   "main": "index.js",
   "repository": "https://github.com/pixelandtonic/vuepress-theme-craftdocs",


### PR DESCRIPTION
Fix issue where build would fail due to empty `page.title`