### PR TITLE
Incorporate feedback widget

### DIFF
--- a/Page.vue
+++ b/Page.vue
@@ -59,20 +59,22 @@
     </div>
 
     <slot name="bottom"/>
-    <div id="happy-thumbs"></div>
+    <votes :frontmatter="this.$page.frontmatter" ref="votes"></votes>
   </div>
 </template>
 
 <script>
 import { resolvePage, normalize, outboundRE, endingSlashRE } from './util'
+import Votes from './Votes'
 
 export default {
   props: ['sidebarItems'],
+  components: {
+    Votes
+  },
 
-  mounted() {
-    const thumbsSrc = document.createElement('script')
-    thumbsSrc.setAttribute('src', 'https://exprmnt.s3.us-west-1.amazonaws.com/happy-thumbs.js')
-    document.head.appendChild(thumbsSrc);
+  updated() {
+    this.$refs.votes.resetVote();
   },
 
   computed: {
@@ -172,7 +174,7 @@ export default {
         (docsDir ? '/' + docsDir.replace(endingSlashRE, '') : '') +
         path
       )
-    }
+    },
   }
 }
 

--- a/Page.vue
+++ b/Page.vue
@@ -59,6 +59,7 @@
     </div>
 
     <slot name="bottom"/>
+    <div id="happy-thumbs"></div>
   </div>
 </template>
 
@@ -67,6 +68,12 @@ import { resolvePage, normalize, outboundRE, endingSlashRE } from './util'
 
 export default {
   props: ['sidebarItems'],
+
+  mounted() {
+    const thumbsSrc = document.createElement('script')
+    thumbsSrc.setAttribute('src', 'https://exprmnt.s3.us-west-1.amazonaws.com/happy-thumbs.js')
+    document.head.appendChild(thumbsSrc);
+  },
 
   computed: {
     lastUpdated () {

--- a/README.md
+++ b/README.md
@@ -103,3 +103,13 @@ code:
 ```
 
 (Use the same language handles defined by `themeConfig.codeLanguages` in `.vuepress/config.js`.)
+
+## Helpful Vote Widget
+
+A “Was this helpful?” widget will be rendered at the bottom of each page, logging votes as Google Analytics events. To disable this, use the `votes` setting in your page’s frontmatter:
+
+```yaml
+---
+votes: false
+---
+```

--- a/Votes.vue
+++ b/Votes.vue
@@ -1,0 +1,44 @@
+<template>
+    <div>
+        <div id="happy-thumbs"></div>
+    </div>
+</template>
+
+<script>
+export default {
+  props: ['frontmatter'],
+  mounted() {
+    const thumbsSrc = document.createElement("script");
+    // TODO: move script to permanent CDN home
+    thumbsSrc.setAttribute(
+      "src",
+      "https://exprmnt.s3.us-west-1.amazonaws.com/happy-thumbs.js"
+    );
+    thumbsSrc.onload = this.resetVote;
+    document.head.appendChild(thumbsSrc);
+  },
+  methods: {
+    resetVote() {
+      if (typeof window.happyThumbs.reset === "function") {
+        window.happyThumbs.reset();
+      }
+
+      if (this.frontmatter.votes === false) {
+        this.disableVoteWidget();
+      } else {
+        this.enableVoteWidget();
+      }
+    },
+    enableVoteWidget() {
+      if (typeof window.happyThumbs.enable === "function") {
+        window.happyThumbs.enable();
+      }
+    },
+    disableVoteWidget() {
+      if (typeof window.happyThumbs.disable === "function") {
+        window.happyThumbs.disable();
+      }
+    }
+  }
+};
+</script>


### PR DESCRIPTION
This adds a “Was this helpful?” widget to each VuePress page and resets it on navigation to a new page. Each vote is recorded as a Google Analytics event for that URL, up being a `1` and down being a `0`.

The externally-referenced JavaScript is meant to be used anywhere we need it, including craftcms.com guides, but should first be hosted on an appropriate CDN and possibly versioned.

This wraps that external script in a Vue component and adds it to the bottom of each VuePress page. It can be hidden by including `votes: false` in any markdown frontmatter.